### PR TITLE
Added some ACL tests for admin vs. non-admin accounts

### DIFF
--- a/contracts/Lootbox.sol
+++ b/contracts/Lootbox.sol
@@ -79,7 +79,8 @@ contract Lootbox is ERC1155Holder, Ownable, Pausable, ReentrancyGuard {
         require(
             getTerminusContract().balanceOf(msg.sender, administratorPoolId) >
                 0 ||
-                msg.sender == owner()
+                msg.sender == owner(),
+            "Lootbox.sol: Sender is not an administrator"
         );
         _;
     }
@@ -94,7 +95,7 @@ contract Lootbox is ERC1155Holder, Ownable, Pausable, ReentrancyGuard {
     function grantAdminRole(address to) public onlyOwner {
         TerminusFacet terminusContract = TerminusFacet(terminusAddress);
         require(
-            msg.sender ==
+            address(this) ==
                 terminusContract.terminusPoolController(administratorPoolId),
             "The contract is not the pool controller for the administrator pool. Please transfer the controller role to the contract."
         );
@@ -104,7 +105,7 @@ contract Lootbox is ERC1155Holder, Ownable, Pausable, ReentrancyGuard {
     function revokeAdminRole(address from) public onlyOwner {
         TerminusFacet terminusContract = TerminusFacet(terminusAddress);
         require(
-            msg.sender ==
+            address(this) ==
                 terminusContract.terminusPoolController(administratorPoolId),
             "The contract is not the pool controller for the administrator pool. Please transfer the controller role to the contract."
         );

--- a/lootbox/core.py
+++ b/lootbox/core.py
@@ -35,7 +35,6 @@ def load_lootbox_item_from_json_file(file_path: str):
 
 
 def gogogo(terminus_address, tx_config) -> Dict[str, Any]:
-
     deployer = tx_config["from"]
     terminus_contract = MockTerminus.MockTerminus(terminus_address)
 


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes
- Added tests for `onlyAdmin` modifier.
- Fixed a bug in `grantAdminRole` and `revokeAdminRole`.


## How to test these changes?

`./test.sh`

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
